### PR TITLE
Update library search path for m1 Macs

### DIFF
--- a/glfw/library.py
+++ b/glfw/library.py
@@ -133,6 +133,7 @@ def _get_library_search_paths():
         '/usr/lib64',
         '/usr/local/lib64',
         '/usr/lib', '/usr/local/lib',
+        '/opt/homebrew/lib',
         '/run/current-system/sw/lib',
         '/usr/lib/x86_64-linux-gnu/',
         '/usr/lib/aarch64-linux-gnu/',


### PR DESCRIPTION
The apple silicon homebrew installs libraries to `/opt/homebrew/lib` instead of `/usr/local/lib`.

Mentioned in https://github.com/FlorianRhiem/pyGLFW/issues/57